### PR TITLE
Feature/69-open-file-explorer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,19 +1,97 @@
-*.iml
-.kotlin
-.gradle
-**/build/
-xcuserdata
-!src/**/build/
-local.properties
-.idea
+# OS
 .DS_Store
-captures
-.externalNativeBuild
-.cxx
-*.xcodeproj/*
+Thumbs.db
+desktop.ini
+Icon?
+
+# IDE
+.idea/
+*.iml
+*.iws
+*.ipr
+workspace.xml
+.idea_modules/
+.vscode/
+.classpath
+.project
+.settings/
+
+# Gradle / build
+.gradle/
+.gradle-test-kit/
+build/
+**/build/
+out/
+!gradle/wrapper/gradle-wrapper.jar
+
+# Kotlin / compiler cache
+.kotlincache/
+.kotlin/
+*.kotlin_module
+
+# Compose Desktop / native distributions
+*.deb
+*.dmg
+*.msi
+*.AppImage
+*.exe
+
+# JVM / Java artifacts
+*.class
+*.jar
+*.war
+*.ear
+
+# Native / Android NDK / KMP native
+.externalNativeBuild/
+.cxx/
+captures/
+
+# Xcode (optional)
+*.xcodeproj/
+*.xcworkspace/
+xcuserdata/
+xcshareddata/
 !*.xcodeproj/project.pbxproj
 !*.xcodeproj/xcshareddata/
 !*.xcodeproj/project.xcworkspace/
 !*.xcworkspace/contents.xcworkspacedata
 **/xcshareddata/WorkspaceSettings.xcsettings
-node_modules/
+
+# Local configs / secrets / signing keys
+local.properties
+secrets.properties
+*.keystore
+*.jks
+.env
+.env.local
+
+# Logs / temp / editor swap
+*.log
+*.tmp
+*.orig
+*.swp
+*~
+
+# Node.js / web (optional)
+# node_modules/
+# /dist/
+# .webpack/
+
+# CI / distribution / misc
+/dist/
+/ci-artifacts/
+
+# Coverage / test outputs
+coverage/
+jacoco/
+*.exec
+*.lcov
+
+# Generic caches
+.cache/
+
+# Archives
+*.zip
+*.tar.gz
+*.rar

--- a/composeApp/src/jvmMain/kotlin/rs/gdgoc/core/App.kt
+++ b/composeApp/src/jvmMain/kotlin/rs/gdgoc/core/App.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.splitpane.ExperimentalSplitPaneApi
+import rs.gdgoc.file_system.openFileExplorer
 import rs.gdgoc.ui.layout.MainLayout
 import rs.gdgoc.ui.menubar.CustomToolbar
 
@@ -18,7 +19,7 @@ fun App() {
         CustomToolbar(
             onRunClick = { println("Run clicked! ") },
             onNewFile = { println("New file") },
-            onOpenFile = { println("Open file") },
+            onOpenFile = {openFileExplorer()},
             onSaveFile = { println("Save file") },
             onExit = {}
         )

--- a/composeApp/src/jvmMain/kotlin/rs/gdgoc/file_system/FileExplorer.kt
+++ b/composeApp/src/jvmMain/kotlin/rs/gdgoc/file_system/FileExplorer.kt
@@ -1,0 +1,26 @@
+package rs.gdgoc.file_system
+
+import java.io.File
+
+/**
+ * Otvara native file manager operativnog sistema u zadatom direktorijumu.
+ * Podrzava Windows (File Explorer), macOS (Finder) i Linux (xdg-open).
+ *
+ * @param path Putanja do direktorijuma koji treba otvoriti.
+ *             Po defaultu otvara home folder trenutnog korisnika.
+ */
+
+
+fun openFileExplorer(path: String = System.getProperty("user.home")) {
+    val os = System.getProperty("os.name").lowercase()
+
+    val command = when {
+        os.contains("win") -> listOf("explorer", path)//windows
+        os.contains("mac") -> listOf("open", path) //mac
+        else -> listOf("xdg-open", path) // Linux
+    }
+
+    ProcessBuilder(command)
+        .directory(File(path))
+        .start()
+}


### PR DESCRIPTION
Added FileExplorerService.kt in rs/gdgoc/file_system which implements cross-platform file explorer launching.
Updated App.kt to call openFileExplorer() when the Open option is clicked from the menu.

Supported platforms:
- Windows → File Explorer
- macOS → Finder
- Linux → xdg-open