### PR TITLE
Feature/51 add run button to toolbar

### DIFF
--- a/composeApp/src/jvmMain/kotlin/rs/gdgoc/core/App.kt
+++ b/composeApp/src/jvmMain/kotlin/rs/gdgoc/core/App.kt
@@ -16,7 +16,7 @@ import rs.gdgoc.ui.menubar.CustomToolbar
 fun App() {
     Column(modifier = Modifier.fillMaxSize()) {
         CustomToolbar(
-            onRunClick = { println("Run clicked! ") },
+            onRunClick = { Runner.start() },
             onNewFile = { println("New file") },
             onOpenFile = { println("Open file") },
             onSaveFile = { println("Save file") },

--- a/composeApp/src/jvmMain/kotlin/rs/gdgoc/core/Runner.kt
+++ b/composeApp/src/jvmMain/kotlin/rs/gdgoc/core/Runner.kt
@@ -1,0 +1,9 @@
+package rs.gdgoc.core
+
+object Runner {
+
+    //Placeholder implementation
+    fun start() {
+        println("[Runner] Run requested (placeholder).")
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/rs/gdgoc/core/Runner.kt
+++ b/composeApp/src/jvmMain/kotlin/rs/gdgoc/core/Runner.kt
@@ -1,5 +1,7 @@
 package rs.gdgoc.core
 
+//Singleton class for runner service module
+//todo: implement everything
 object Runner {
 
     //Placeholder implementation

--- a/composeApp/src/jvmMain/kotlin/rs/gdgoc/ui/menubar/CustomToolbar.kt
+++ b/composeApp/src/jvmMain/kotlin/rs/gdgoc/ui/menubar/CustomToolbar.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Divider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -58,6 +59,16 @@ fun CustomToolbar(
 
         Spacer(modifier = Modifier.weight(1f))
 
+        Divider(
+            modifier = Modifier
+                .fillMaxHeight()
+                .width(1.dp)
+                .padding(vertical = 6.dp),
+            color = Color(0xFFBDBDBD)
+        )
+
+        Spacer(modifier = Modifier.width(8.dp))
+
         Button(
             onClick = onRunClick,
             colors = ButtonDefaults.buttonColors(
@@ -65,10 +76,8 @@ fun CustomToolbar(
             ),
             modifier = Modifier.height(32.dp)
         ) {
-            Spacer(modifier = Modifier.width(4.dp))
             Text("Run", color = Color.White)
         }
 
-        Spacer(modifier = Modifier. weight(1f))
     }
 }


### PR DESCRIPTION
The run button was moved to the right and now has a small vertical separator line. 
A Runner singleton class was created with a placeholder start function. 
The start function was connected to the run button.